### PR TITLE
Fix slash command behavior

### DIFF
--- a/src/commands/utility/ping.ts
+++ b/src/commands/utility/ping.ts
@@ -1,24 +1,50 @@
-import { EmbedBuilder,ColorResolvable  } from 'discord.js';
+import { EmbedBuilder, ColorResolvable, SlashCommandBuilder } from 'discord.js';
 import { Command } from '../../types/command';
 import { config } from '../../config';
 
 const ping: Command = 
 {
-  options: 
-  {
+  options: {
     name: 'ping',
     description: 'Check bot latency and response time',
     category: 'utility',
     aliases: ['pong', 'latency'],
-    cooldown: 5
+    cooldown: 5,
+    slashCommand: true,
+    slashData: new SlashCommandBuilder()
+      .setName('ping')
+      .setDescription('Check bot latency and response time'),
   },
   
-  execute: async ({ client, message }) => 
-  {
+  execute: async ({ client, message, interaction }) => {
+    // Slash command handling
+    if (!message && interaction) {
+      await interaction.reply('🏓 Pinging...');
+      const sent = await interaction.fetchReply();
+
+      const botLatency = sent.createdTimestamp - interaction.createdTimestamp;
+      const apiLatency = Math.round(client.ws.ping);
+
+      const defaultColor = (config.embedColor as string) || '#2d0036';
+      const embed = new EmbedBuilder()
+        .setColor(defaultColor as ColorResolvable)
+        .setTitle('🏓 Pong!')
+        .addFields(
+          { name: '📡 Bot Latency', value: `${botLatency}ms`, inline: true },
+          { name: '🌐 API Latency', value: `${apiLatency}ms`, inline: true },
+          { name: '⏱️ Uptime', value: `${Math.floor(client.uptime! / 1000 / 60)} minutes`, inline: true }
+        )
+        .setTimestamp()
+        .setFooter({ text: `Requested by ${interaction.user.tag}` });
+
+      await interaction.editReply({ content: '', embeds: [embed] });
+      return;
+    }
+
     if (!message) return;
 
     const sent = await message.reply('🏓 Pinging...');
-    
+
     const botLatency = sent.createdTimestamp - message.createdTimestamp;
     const apiLatency = Math.round(client.ws.ping);
 

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -35,12 +35,16 @@ const commandFiles = getCommandFiles(join(__dirname, 'commands'));
 for (const file of commandFiles) {
   const commandModule = require(file);
   const command = commandModule.default || commandModule;
-  if (command && command.options && command.options.name && command.options.description) {
-    // If the command has a slashData (SlashCommandBuilder), use it
+  if (
+    command &&
+    command.options &&
+    command.options.slashCommand &&
+    command.options.name &&
+    command.options.description
+  ) {
     if (command.options.slashData instanceof SlashCommandBuilder) {
       commands.push(command.options.slashData.toJSON());
     } else {
-      // Otherwise, register as a basic slash command
       commands.push(
         new SlashCommandBuilder()
           .setName(command.options.name)

--- a/src/types/better-sqlite3.d.ts
+++ b/src/types/better-sqlite3.d.ts
@@ -1,0 +1,4 @@
+declare module 'better-sqlite3' {
+  const Database: any;
+  export default Database;
+}

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -70,6 +70,8 @@ export interface Command {
     ownerOnly?: boolean;
     guildOnly?: boolean;
     cooldown?: number;
+    slashCommand?: boolean;
+    slashData?: SlashCommandBuilder;
     // Add more options as needed
   };
   execute: (options: CommandExecuteOptions) => Promise<void>;


### PR DESCRIPTION
## Summary
- support slash commands in ping utility
- only register slash-enabled commands in deploy script
- expand command type definitions
- add module declaration for better-sqlite3

## Testing
- `npm run build` *(fails: Cannot find module 'node-fetch' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68710824bd948320b0703c2f19cfb447